### PR TITLE
Update grub2 with argon2 on backup.nix

### DIFF
--- a/profiles/packages/grub/backup.nix
+++ b/profiles/packages/grub/backup.nix
@@ -1,111 +1,78 @@
-{ ... }: {}
-# grub2 = prev.grub2.overrideAttrs (oa: {
-#   version = "2.06.r291";
-#   src = prev.fetchgit {
-#     url = "https://git.savannah.gnu.org/git/grub.git";
-#     rev = "e43f3d93b28cce852c110c7a8e40d8311bcd8bb1";
-#     hash = "sha256-8M0WqeDE4Hrwq/zlygfbAWUt7vdDeqfJLX1ADzQGM3I=";
-#   };
-#   patches = [
-#     ./packages/grub/fix-bash-completion.patch
-#     ./packages/grub/add-hidden-menu-entries.patch
-#     ./packages/grub/license.patch
-#     ./packages/grub/5000-grub-2.06-luks2-argon2-v4.patch
-#     ./packages/grub/9500-grub-AUR-improved-luks2.patch
-#   ];
+final: prev: {
+  grub2 = prev.grub2.overrideAttrs (attrs: {
+    version = "2.06.r499.ge67a551a4";
 
-#   # GRUB_AUTOGEN="1";
+    src = prev.fetchgit {
+      url = "https://git.savannah.gnu.org/git/grub.git";
+      rev = "e67a551a48192a04ab705fca832d82f850162b64";
+      hash = "sha256-HycIXy8qf56JVQP5KUavfNShyU0hE+/HrdbT/ZBnzzI=";
+    };
 
-#   nativeBuildInputs = with prev; [ bison flex python3 pkg-config gettext freetype autoconf automake ];
-#   # nativeBuildInputs = oa.nativeBuildInputs ++ [
-#     # prev.autoconf prev.automake
-#   #   prev.autogen
-#   #   # prev.libargon2
-#   # ];
+    patches = [
+      ./fix-bash-completion.patch
+      (prev.fetchpatch {
+        name = "Add-hidden-menu-entries.patch";
+        # https://lists.gnu.org/archive/html/grub-devel/2016-04/msg00089.html
+        url = "https://marc.info/?l=grub-devel&m=146193404929072&q=mbox";
+        sha256 = "00wa1q5adiass6i0x7p98vynj9vsz1w0gn1g4dgz89v35mpyw2bi";
+      })
 
-#   # buildInputs = oa.buildInputs ++ [ prev.libargon2 ];
-#   # CPPFLAGS="-O2";
-#   # NIX_CFLAGS_COMPILE = "-Wno-error -O2";
+      # argon2 patches from AUR: https://aur.archlinux.org/packages/grub-improved-luks2-git
+      (prev.fetchpatch {
+        name = "argon_1.patch";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/argon_1.patch?h=grub-improved-luks2-git";
+        sha256 = "sha256-WCt+sVr8Ss/bAI41yMJmcZoIPVO1HFEjw1OVRUPYb+w=";
+      })
+      (prev.fetchpatch {
+        name = "argon_2.patch";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/argon_2.patch?h=grub-improved-luks2-git";
+        sha256 = "sha256-OMQYjTFq0PpO38wAAXRsYUfY8nWoAMcPhKUlbqizIS8=";
+      })
+      (prev.fetchpatch {
+        name = "argon_3.patch";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/argon_3.patch?h=grub-improved-luks2-git";
+        sha256 = "sha256-rxtvrBG4HhGYIvpIGZ7luNH5GPbl7TlqbNHcnR7IZc8=";
+      })
+      (prev.fetchpatch {
+        name = "argon_4.patch";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/argon_4.patch?h=grub-improved-luks2-git";
+        sha256 = "sha256-Hz88P8T5O2ANetnAgfmiJLsucSsdeqZ1FYQQLX0WP3I=";
+      })
+      (prev.fetchpatch {
+        name = "argon_5.patch";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/argon_5.patch?h=grub-improved-luks2-git";
+        sha256 = "sha256-cs5dKI2Am+Kp0/ZqSWqd2h/7Oj+WEBeKgWPVsCeMgwk=";
+      })
+      (prev.fetchpatch {
+        name = "grub-install_luks2.patch";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/grub-install_luks2.patch?h=grub-improved-luks2-git";
+        sha256 = "sha256-I+1Yl0DVBDWFY3+EUPbE6FTdWsKH81DLP/2lGPVJtLI=";
+      })
+    ];
+    nativeBuildInputs = (builtins.filter (x: x.name != "autoreconf-hook") attrs.nativeBuildInputs) ++ (with final; [autoconf automake]);
 
-#   # configureFlags = [
-#   #   "GRUB_ENABLE_CRYPTODISK=y"
-#   #   "TARGET_CFLAGS=-O2"
-#   #   "--disable-werror"
-#   #   "CFLAGS=\"\${CFLAGS/-fno-plt}\""
-#   #   "CPPFLAGS=\"-O2\""
-#   #   "--disable-silent-rules"
-#   #   "--disable-werror"
-#   # ] ++ oa.configureFlags;
-#   # NIX_CFLAGS_COMPILE = "-O2";
-#   # CFLAGS="-fno-plt";
-#   # configureFlags = oa.configureFlags ++ [
-#   #   # "--enable-boot-time"
-#   #   # "--enable-cache-stats"
-#   #   # "--enable-device-mapper"
-#   #   # "--enable-grub-mkfont"
-#   #   # "--enable-grub-mount"
-#   #   # "--enable-mm-debug"
-#   #   "--disable-silent-rules"
-#   #   "--disable-werror"
-#   #   # "CPPFLAGS=\"$CPPFLAGS -O2\""
-#   # ];
-#   preConfigure = with prev; ''
-#     for i in "tests/util/"*.in
-#     do
-#       sed -i "$i" -e's|/bin/bash|${stdenv.shell}|g'
-#     done
-#     # Apparently, the QEMU executable is no longer called
-#     # `qemu-system-i386', even on i386.
-#     #
-#     # In addition, use `-nodefaults' to avoid errors like:
-#     #
-#     #  chardev: opening backend "stdio" failed
-#     #  qemu: could not open serial device 'stdio': Invalid argument
-#     #
-#     # See <http://www.mail-archive.com/qemu-devel@nongnu.org/msg22775.html>.
-#     sed -i "tests/util/grub-shell.in" \
-#         -e's/qemu-system-i386/qemu-system-x86_64 -nodefaults/g'
-#     unset CPP # setting CPP intereferes with dependency calculation
+    preConfigure = let
+      gnulib = final.fetchgit {
+        url = "https://git.savannah.gnu.org/r/gnulib.git";
+        rev = "06b2e943be39284783ff81ac6c9503200f41dba3";
+        sha256 = "sha256-xhxN8Tw15ENAMSE/cTkigl5yHR3T2d7B1RMFqiMvmxU=";
+      };
+    in
+      builtins.replaceStrings ["patchShebangs ."] [
+        ''
+          patchShebangs .
 
-#     patchShebangs .
+          ./bootstrap --no-git --gnulib-srcdir=${gnulib}
+        ''
+      ]
+      attrs.preConfigure;
 
-#     ./bootstrap --no-git --gnulib-srcdir=${gnulib} # my changes
-
-#     substituteInPlace ./configure --replace '/usr/share/fonts/unifont' '${unifont}/share/fonts'
-
-#     sed -i 's/idx_t/grub_size_t/g' ./grub-core/disk/luks2.c # my changes
-#   '';
-#   # preConfigure = oa.preConfigure + ''
-#   #   echo "I'm here!"
-#   #   ./bootstrap --no-git --gnulib-srcdir=${prev.gnulib}
-#   # '';
-#   # postPatch = let
-#   #   bash-patch = ./packages/grub/fix-bash-completion.patch;
-#   #   menu-patch = ./packages/grub/add-hidden-menu-entries.patch;
-#   #   # alloc-patch = ./packages/grub/4500-grub-2.06-runtime-memregion-alloc.patch;
-#   #   luks-argon2-patch = ./packages/grub/5000-grub-2.06-luks2-argon2-v4.patch;
-#   #   luks2-patch = ./packages/grub/9500-grub-AUR-improved-luks2.patch;
-#   #   argon1-patch = ./packages/grub/argon_1.patch;
-#   #   argon2-patch = ./packages/grub/argon_2.patch;
-#   #   argon3-patch = ./packages/grub/argon_3.patch;
-#   #   argon4-patch = ./packages/grub/argon_4.patch;
-#   #   argon5-patch = ./packages/grub/argon_5.patch;
-#   # in ''
-#   #   patch -Np1 -i "${bash-patch}"
-#   #   patch -Np1 -i "${menu-patch}"
-#   #   # patch -Np1 -i "${argon1-patch}"
-#   #   # patch -Np1 -i "${argon2-patch}"
-#   #   # patch -Np1 -i "${argon3-patch}"
-#   #   # patch -Np1 -i "${argon4-patch}"
-#   #   # patch -Np1 -i "${argon5-patch}"
-#   #   patch -Np1 -i "${luks-argon2-patch}"
-#   #   patch -Np1 -i "${luks2-patch}"
-#   #   # ls -lah ./
-#   #   # ls -lah ./grub-core
-#   #   # echo "CFLAGS"
-#   #   # echo $CFLAGS
-#   #   # sed -i 's#rm -f kernel_syms.input#cat kernel_syms.input; rm -f kernel_syms.input#' ./grub-core/Makefile.am
-#   #   # sed -i 's#cat $<#cat $<\n\tcat $<#' ./grub-core/Makefile.am
-#   #   # exit 1
-#   # '' + oa.postPatch;
-# });
+    configureFlags =
+      attrs.configureFlags
+      ++ [
+        "--disable-nls"
+        "--disable-silent-rules"
+        "--disable-werror"
+      ];
+  });
+}


### PR DESCRIPTION
This uses the latest grub2-git commit, plus patches in [AUR's grub-improved-luks2-git](https://aur.archlinux.org/packages/grub-improved-luks2-git). Notice `type-fix.patch` is due to outdated gnulib, but that can't be on HEAD either since it breaks build; the commit I used in let/in makes it work.
This is done in a way to keep maximum compatibility with nixpkgs's grub2 package.

I'm running this one on my current system with `boot` on `btrfs` on `luks2+argon2id` on `mdraid1`.
Grub takes a good 45s to derive the key (while initrd/kernel takes just 1-2 seconds), but I don't reboot very often and prefer this way for the added security and minimal boot footprint (just a single, standalone and portable 420kB `BOOTX64.efi` on EFI partition and everything else inside btrfs).

<details><summary>My config (install with `NIXOS_INSTALL_BOOTLOADER=1 nixos-rebuild boot`)</summary>
<p>

```nix
    boot.loader = {
      efi = {
        canTouchEfiVariables = false;
        efiSysMountPoint = "/boot/efi";
      };
      grub = let
        grub = pkgs.grub2_efi;
        modules = "part_gpt luks2 lvm mdraid1x cryptodisk gcry_rijndael gcry_sha256 gcry_sha512 pbkdf2 btrfs true";
        inherit (lib) escapeShellArg;
        stub = "${config.boot.loader.efi.efiSysMountPoint}/EFI/BOOT/BOOTX64.EFI";
      in {
        enable = true;
        enableCryptodisk = true;
        efiSupport = true;
        efiInstallAsRemovable = true;
        # extraGrubInstallArgs = [ "--modules=${modules}" ];
        device = "nodev";
        gfxmodeEfi = "1920x1080x32,1920x1080x24,1024x768x32,1024x768x24,auto";
        extraInstallCommands = ''
          grub_tmp=$(mktemp -d -t grub.conf.XXXXXXXX)
          trap 'rm -rf -- "$grub_tmp"' EXIT
          cat <<EOS >"$grub_tmp/grub.cfg"
            cryptomount -u $(${pkgs.utillinux}/bin/blkid -o value -s UUID ${escapeShellArg config.boot.initrd.luks.devices."enc".device})
            set root=(crypto0)
            set prefix=(crypto0)/boot/grub
          EOS

          mkdir -p ${escapeShellArg (builtins.dirOf stub)}
          ${grub}/bin/grub-mkimage \
            -p '(crypto0)/boot/grub' \
            -O ${grub.grubTarget} \
            -c $grub_tmp/grub.cfg \
            -o ${escapeShellArg stub} \
            ${modules}
        '';
      };
    };
```
</p>
</details> 

I'm making a PR on your repo, as it was the only public one I found on Github with a somehow working version of grub2-git + argon2 patches for NixOS.

If you find these changes useful, please, feel free to take over this PR and adapt it to your repo, replacing/adapting other files as needed (e.g. most of the currently committed patches aren't needed anymore and are being fetched directly from aur's repo).